### PR TITLE
Fix aruba template

### DIFF
--- a/Aruba/Aruba2930F-SSH-NoEnable.yml
+++ b/Aruba/Aruba2930F-SSH-NoEnable.yml
@@ -36,7 +36,7 @@ config:
     # Disable config scrolling/ paging command. on/off
     paging: on
     # Disable config scrolling/ paging command. Leave blank, or set as required. Must place command in quotations
-    pagingCmd: "nno page"
+    pagingCmd: "no page"
     # re-enable config scrolling/ paging command. Leave blank, or set as required. Must place command in quotations
     resetPagingCmd: "page"
     # Set pager prompt. Must place command in quotations

--- a/HP/hp-procurve-ssh-noenable-v2.yml
+++ b/HP/hp-procurve-ssh-noenable-v2.yml
@@ -36,7 +36,7 @@ config:
     # Disable config scrolling/ paging command. on/off
     paging: on
     # Disable config scrolling/ paging command. Leave blank, or set as required. Must place command in quotations
-    pagingCmd: "nno page"
+    pagingCmd: "no page"
     # re-enable config scrolling/ paging command. Leave blank, or set as required. Must place command in quotations
     resetPagingCmd: "page"
     # Set pager prompt. Must place command in quotations


### PR DESCRIPTION
There seems to be a typo in the HP and Aruba templates.  The paging command is listed as "nno page" but the documentation for the switches states that the command should in fact be "no page".